### PR TITLE
fix: unclip onUpdateTime tooltip broken in Vaadin 24

### DIFF
--- a/vcf-timeline/src/main/resources/META-INF/resources/frontend/styles/timeline.css
+++ b/vcf-timeline/src/main/resources/META-INF/resources/frontend/styles/timeline.css
@@ -7,13 +7,11 @@
 }
 
 .timeline .vis-timeline {
-	overflow-y: visible;
-    overflow-x: clip;
+    overflow: visible !important;
 }
 
 .timeline .vis-center {
-	overflow-y: visible;
-    overflow-x: clip;
+    overflow: visible !important;
 }
 
 .timeline .vis-item .vis-onUpdateTime-tooltip{


### PR DESCRIPTION
This PR includes an update to use `overflow: visible !important` on `.vis-timeline` and `.vis-center` to restore tooltip visibility in 24 and keep it compatible with both Vaadin 14 & Vaadin 24.

Tested in Vaadin 14 & Vaadin 24.

Close #39